### PR TITLE
Add check if DS constant already defined

### DIFF
--- a/path.php
+++ b/path.php
@@ -2,7 +2,9 @@
 
 namespace Donut\Path;
 
-define("DS", \DIRECTORY_SEPARATOR);
+if (!defined('DS')) {
+  define("DS", \DIRECTORY_SEPARATOR);
+}
 
 function canonicalize($path, $root=null) {
 


### PR DESCRIPTION
The phinx project is using php-path and is defining DS before autoloading it.  This is resulting in a notice about DS already being defined.  This change will stop the notice from being raised.
